### PR TITLE
Update Gradle to 7.4 

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -1,12 +1,12 @@
 plugins {
-    id("com.android.application")
-    kotlin("android")
-    id("com.google.gms.google-services")
-    id("com.google.firebase.crashlytics")
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.firebase.crashlytics)
+    alias(libs.plugins.google.services)
+    alias(libs.plugins.kotlin.android)
 }
 
 dependencies {
-    implementation(project(":shared"))
+    implementation(projects.shared)
 
     // Firebase
     implementation (platform(libs.firebase.bom))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,21 +7,10 @@ plugins {
 }
 
 buildscript {
-    val kotlinVersion: String by project
-    println("Using Kotlin Version: $kotlinVersion")
-
     repositories {
         gradlePluginPortal()
         google()
         mavenCentral()
-    }
-    dependencies {
-        classpath(libs.kotlin.plugin)
-        classpath(libs.kotlin.serialization.plugin)
-        classpath(libs.android.build.plugin)
-        classpath(libs.buildkonfig.plugin)
-        classpath(libs.google.services.plugin)
-        classpath(libs.firebase.crashlytics.plugin)
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,3 @@
-kotlinVersion=1.6.10
-
 #Gradle
 org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+android-plugin = "7.1.0"
 androidx-compose = "1.1.0-rc03"
 androidx-test = "1.4.1-alpha03"
 coil = "1.4.0"
@@ -10,7 +11,6 @@ multiplatform-settings = "0.8.1"
 
 [libraries]
 accompanist-insets-ui = "com.google.accompanist:accompanist-insets-ui:0.22.1-rc"
-android-build-plugin = "com.android.tools.build:gradle:7.1.0"
 androidx-activity-compose = "androidx.activity:activity-compose:1.4.0"
 androidx-compose-foundation = "androidx.compose.foundation:foundation:1.1.0-rc03"
 androidx-compose-material = { module = "androidx.compose.material:material", version.ref = "androidx-compose" }
@@ -27,14 +27,12 @@ androidx-test-espresso-core = "androidx.test.espresso:espresso-core:3.4.0"
 androidx-test-junit = "androidx.test.ext:junit:1.1.3"
 androidx-test-orchestrator = { module = "androidx.test:orchestrator", version.ref = "androidx-test" }
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test" }
-buildkonfig-plugin = "com.codingfeline.buildkonfig:buildkonfig-gradle-plugin:0.11.0"
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 coil-gif = { module = "io.coil-kt:coil-gif", version.ref = "coil" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics-ktx" }
 firebase-bom = "com.google.firebase:firebase-bom:29.0.4"
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics-ktx" }
-firebase-crashlytics-plugin = "com.google.firebase:firebase-crashlytics-gradle:2.8.1"
-google-services-plugin = "com.google.gms:google-services:4.3.10"
+
 junit = "junit:junit:4.13.2"
 kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
 kermit-crashlytics = { module = "co.touchlab:kermit-crashlytics", version.ref = "kermit" }
@@ -56,6 +54,14 @@ multiplatform-settings-test = { module = "com.russhwolf:multiplatform-settings-t
 uuid = "com.benasher44:uuid:0.4.0"
 
 [plugins]
+android-library = { id = "com.android.library", version.ref = "android-plugin" }
+android-application = { id = "com.android.application", version.ref = "android-plugin" }
+buildkonfig = "com.codingfeline.buildkonfig:0.11.0"
+firebase-crashlytics = "com.google.firebase.crashlytics:2.8.1"
+google-services = "com.google.gms.google-services:4.3.10"
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin"}
+kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin"}
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin"}
 spotless = "com.diffplug.spotless:6.2.1"
 version-catalog-update = "nl.littlerobots.version-catalog-update:0.3.0"
 versions = "com.github.ben-manes.versions:0.41.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-android-plugin = "7.1.0"
-androidx-compose = "1.1.0-rc03"
+android-plugin = "7.1.1"
+androidx-compose = "1.1.0"
 androidx-test = "1.4.1-alpha03"
 coil = "1.4.0"
 kermit = "1.0.3"
@@ -10,9 +10,9 @@ ktor = "2.0.0-beta-1"
 multiplatform-settings = "0.8.1"
 
 [libraries]
-accompanist-insets-ui = "com.google.accompanist:accompanist-insets-ui:0.22.1-rc"
+accompanist-insets-ui = "com.google.accompanist:accompanist-insets-ui:0.23.0"
 androidx-activity-compose = "androidx.activity:activity-compose:1.4.0"
-androidx-compose-foundation = "androidx.compose.foundation:foundation:1.1.0-rc03"
+androidx-compose-foundation = "androidx.compose.foundation:foundation:1.1.0"
 androidx-compose-material = { module = "androidx.compose.material:material", version.ref = "androidx-compose" }
 androidx-compose-material-icons-core = { module = "androidx.compose.material:material-icons-core", version.ref = "androidx-compose" }
 androidx-compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "androidx-compose" }
@@ -21,8 +21,8 @@ androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4
 androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "androidx-compose" }
 androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "androidx-compose" }
 androidx-datastore-preferences = "androidx.datastore:datastore-preferences:1.0.0"
-androidx-lifecycle-viewmodel = "androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.0"
-androidx-startup-runtime = "androidx.startup:startup-runtime:1.1.0"
+androidx-lifecycle-viewmodel = "androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.1"
+androidx-startup-runtime = "androidx.startup:startup-runtime:1.1.1"
 androidx-test-espresso-core = "androidx.test.espresso:espresso-core:3.4.0"
 androidx-test-junit = "androidx.test.ext:junit:1.1.3"
 androidx-test-orchestrator = { module = "androidx.test:orchestrator", version.ref = "androidx-test" }
@@ -32,12 +32,10 @@ coil-gif = { module = "io.coil-kt:coil-gif", version.ref = "coil" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics-ktx" }
 firebase-bom = "com.google.firebase:firebase-bom:29.0.4"
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics-ktx" }
-
 junit = "junit:junit:4.13.2"
 kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
 kermit-crashlytics = { module = "co.touchlab:kermit-crashlytics", version.ref = "kermit" }
 kermit-test = { module = "co.touchlab:kermit-test", version.ref = "kermit" }
-kotlin-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-serialization-plugin = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlin" }
 kotlin-test-annotations-common = { module = "org.jetbrains.kotlin:kotlin-test-annotations-common", version.ref = "kotlin" }
 kotlin-test-common = { module = "org.jetbrains.kotlin:kotlin-test-common", version.ref = "kotlin" }
@@ -54,14 +52,14 @@ multiplatform-settings-test = { module = "com.russhwolf:multiplatform-settings-t
 uuid = "com.benasher44:uuid:0.4.0"
 
 [plugins]
-android-library = { id = "com.android.library", version.ref = "android-plugin" }
 android-application = { id = "com.android.application", version.ref = "android-plugin" }
+android-library = { id = "com.android.library", version.ref = "android-plugin" }
 buildkonfig = "com.codingfeline.buildkonfig:0.11.0"
 firebase-crashlytics = "com.google.firebase.crashlytics:2.8.1"
 google-services = "com.google.gms.google-services:4.3.10"
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin"}
-kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin"}
-kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin"}
-spotless = "com.diffplug.spotless:6.2.1"
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+spotless = "com.diffplug.spotless:6.2.2"
 version-catalog-update = "nl.littlerobots.version-catalog-update:0.3.0"
-versions = "com.github.ben-manes.versions:0.41.0"
+versions = "com.github.ben-manes.versions:0.42.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-enableFeaturePreview("VERSION_CATALOGS")
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 pluginManagement {
     repositories {

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -3,10 +3,10 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 plugins {
-    kotlin("multiplatform")
-    id("com.android.library")
-    kotlin("plugin.serialization")
-    id("com.codingfeline.buildkonfig")
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.buildkonfig)
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 kotlin {


### PR DESCRIPTION
- version catalogues are stable (not need to specify feature),
- instead, add feature preview for typesafe project accessors,
- use plugins from version catalogue (had to remove classpath deps),

Big shout-out to https://github.com/code-with-the-italians/bundel
for inspiration.